### PR TITLE
Webhook support

### DIFF
--- a/git/github_repositories.go
+++ b/git/github_repositories.go
@@ -9,11 +9,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-var (
-	githubHookName = "web"
-
-	ErrorNotFound = errors.New("not found")
-)
+var ErrorNotFound = errors.New("not found")
 
 type GithubRepositories struct {
 	client *api.Client
@@ -104,14 +100,19 @@ func (service *GithubRepositories) Track(fullName, callbackURL string) error {
 }
 
 func (service *GithubRepositories) registerPushWebhook(owner, repo, cbURL string) error {
-	_, response, err := service.client.Repositories.CreateHook(owner, repo, &api.Hook{
-		Name:   &githubHookName,
+	hook := &api.Hook{
+		Name:   new(string),
+		Active: new(bool),
 		Events: []string{"push"},
 		Config: map[string]interface{}{
 			"url":          cbURL,
 			"content_type": "json",
 		},
-	})
+	}
+	*hook.Name = "web"
+	*hook.Active = true
+
+	_, response, err := service.client.Repositories.CreateHook(owner, repo, hook)
 	if err == nil {
 		err = api.CheckResponse(response.Response)
 	}

--- a/git/github_repositories.go
+++ b/git/github_repositories.go
@@ -50,7 +50,7 @@ func (service *GithubRepositories) All() ([]*Repository, error) {
 			paginatedRepos[i] = &Repository{
 				FullName:    *githubRepo.FullName,
 				Description: *githubRepo.Description,
-				Master:      *githubRepo.MasterBranch,
+				Master:      *githubRepo.DefaultBranch,
 				HTMLURL:     *githubRepo.HTMLURL,
 			}
 		}
@@ -82,7 +82,7 @@ func (service *GithubRepositories) Get(fullName string) (*Repository, error) {
 		return nil, err
 	}
 
-	masterBranch, _, err := service.client.Repositories.GetBranch(repoOwner, repoName, *githubRepo.MasterBranch)
+	masterBranch, _, err := service.client.Repositories.GetBranch(repoOwner, repoName, *githubRepo.DefaultBranch)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func repositoryFromGithub(githubRepo *api.Repository) *Repository {
 	return &Repository{
 		FullName:    *githubRepo.FullName,
 		Description: *githubRepo.Description,
-		Master:      *githubRepo.MasterBranch,
+		Master:      *githubRepo.DefaultBranch,
 		HTMLURL:     *githubRepo.HTMLURL,
 		GitURL:      *githubRepo.GitURL,
 	}

--- a/git/github_repositories.go
+++ b/git/github_repositories.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	githubHookName = "doppelganger-copy-on-push"
+	githubHookName = "web"
 
 	ErrorNotFound = errors.New("not found")
 )

--- a/git/services.go
+++ b/git/services.go
@@ -4,3 +4,10 @@ type RepositoryService interface {
 	All() ([]*Repository, error)
 	Get(name string) (*Repository, error)
 }
+
+type MirrorService interface {
+	RepositoryService
+
+	Create(name, url string) error
+	Update(name string) error
+}

--- a/git/services.go
+++ b/git/services.go
@@ -11,3 +11,7 @@ type MirrorService interface {
 	Create(name, url string) error
 	Update(name string) error
 }
+
+type TrackingService interface {
+	Track(name, callbackURL string) error
+}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	http.Handle("/", NewReposHandler(repositoryService))
 	http.Handle("/mirrored", NewReposHandler(mirroredRepositoryService))
 	http.Handle("/mirror", NewMirrorHandler(repositoryService, mirroredRepositoryService, repositoryService))
+	http.Handle("/apihook", NewWebhookHandler(mirroredRepositoryService))
 
 	*addr = fmt.Sprintf("%s:%d", *addr, *port)
 	log.Printf("doppelganger is listening on %s", *addr)

--- a/main.go
+++ b/main.go
@@ -39,5 +39,7 @@ func main() {
 
 	*addr = fmt.Sprintf("%s:%d", *addr, *port)
 	log.Printf("doppelganger is listening on %s", *addr)
-	http.ListenAndServe(*addr, nil)
+	if err := http.ListenAndServe(*addr, nil); err != nil {
+		log.Panic(err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	http.Handle("/", NewReposHandler(repositoryService))
 	http.Handle("/mirrored", NewReposHandler(mirroredRepositoryService))
-	http.Handle("/mirror", NewMirrorHandler(repositoryService, mirroredRepositoryService))
+	http.Handle("/mirror", NewMirrorHandler(repositoryService, mirroredRepositoryService, repositoryService))
 
 	*addr = fmt.Sprintf("%s:%d", *addr, *port)
 	log.Printf("doppelganger is listening on %s", *addr)

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -43,7 +43,16 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 
 		log.Printf("mirrored %s [%s]", repoName, time.Since(startTime))
-		handler.redirectToRepository(w, req, repoName)
+		if req.FormValue("notrack") != "" {
+			handler.redirectToRepository(w, req, repoName)
+			return
+		}
+
+		// Redirect to /mirror?action=track&repo=<repoName> to set up webhook
+		q := req.Form
+		q.Set("action", "track")
+		req.URL.RawQuery = q.Encode()
+		http.Redirect(w, req, req.URL.String(), http.StatusSeeOther)
 	case "update":
 		if err := handler.UpdateMirror(w, repoName); err != nil {
 			log.Printf("failed to update mirror %s: %s", repoName, err)

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -40,6 +40,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 
 		log.Printf("mirrored %s [%s]", repoName, time.Since(startTime))
+		handler.redirectToRepository(w, req, repoName)
 	case "update":
 		if err := handler.UpdateMirror(w, repoName); err != nil {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -47,12 +48,10 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 
 		log.Printf("updated mirror %s [%s]", repoName, time.Since(startTime))
+		handler.redirectToRepository(w, req, repoName)
 	default:
 		http.Error(w, fmt.Sprintf("Unsupported action %q", action), http.StatusBadRequest)
-		return
 	}
-
-	http.Redirect(w, req, fmt.Sprintf("/mirrored?repo=%s", url.QueryEscape(repoName)), http.StatusSeeOther)
 }
 
 func (handler *MirrorHandler) CreateMirror(w http.ResponseWriter, repoName string) error {
@@ -77,4 +76,8 @@ func (handler *MirrorHandler) UpdateMirror(w http.ResponseWriter, repoName strin
 	default:
 		return err
 	}
+}
+
+func (handler *MirrorHandler) redirectToRepository(w http.ResponseWriter, req *http.Request, repoName string) {
+	http.Redirect(w, req, fmt.Sprintf("/mirrored?repo=%s", url.QueryEscape(repoName)), http.StatusSeeOther)
 }

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -37,6 +37,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	switch action := strings.ToLower(req.FormValue("action")); action {
 	case "create":
 		if err := handler.CreateMirror(w, repoName); err != nil {
+			log.Printf("failed to create mirror %s: %s", repoName, err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
@@ -45,6 +46,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		handler.redirectToRepository(w, req, repoName)
 	case "update":
 		if err := handler.UpdateMirror(w, repoName); err != nil {
+			log.Printf("failed to update mirror %s: %s", repoName, err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
@@ -58,6 +60,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 
 		if err := handler.SetupChangeTracking(w, req, repoName); err != nil {
+			log.Printf("failed to track changes for mirror %s: %s", repoName, err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -12,11 +12,11 @@ import (
 )
 
 type MirrorHandler struct {
-	githubRepos   *git.GithubRepositories
-	mirroredRepos *git.MirroredRepositories
+	githubRepos   git.RepositoryService
+	mirroredRepos git.MirrorService
 }
 
-func NewMirrorHandler(githubRepos *git.GithubRepositories, mirroredRepos *git.MirroredRepositories) *MirrorHandler {
+func NewMirrorHandler(githubRepos git.RepositoryService, mirroredRepos git.MirrorService) *MirrorHandler {
 	return &MirrorHandler{
 		githubRepos:   githubRepos,
 		mirroredRepos: mirroredRepos,
@@ -68,7 +68,7 @@ func (handler *MirrorHandler) CreateMirror(w http.ResponseWriter, repoName strin
 }
 
 func (handler *MirrorHandler) UpdateMirror(w http.ResponseWriter, repoName string) error {
-	switch repo, err := handler.githubRepos.Get(repoName); err {
+	switch repo, err := handler.mirroredRepos.Get(repoName); err {
 	case nil:
 		return handler.mirroredRepos.Update(repo.FullName)
 	case git.ErrorNotMirrored:

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -51,6 +51,19 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 
 		log.Printf("updated mirror %s [%s]", repoName, time.Since(startTime))
 		handler.redirectToRepository(w, req, repoName)
+	case "track":
+		if handler.trackRepoService == nil {
+			http.Error(w, "Tracking changes not supported", http.StatusNotImplemented)
+			return
+		}
+
+		if err := handler.SetupChangeTracking(w, req, repoName); err != nil {
+			http.Error(w, "Internal service error", http.StatusInternalServerError)
+			return
+		}
+
+		log.Printf("set up push changes hook for %s [%s]", repoName, time.Since(startTime))
+		handler.redirectToRepository(w, req, repoName)
 	default:
 		http.Error(w, fmt.Sprintf("Unsupported action %q", action), http.StatusBadRequest)
 	}

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -58,7 +58,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 
 		if err := handler.SetupChangeTracking(w, req, repoName); err != nil {
-			http.Error(w, "Internal service error", http.StatusInternalServerError)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 

--- a/webhook_handler.go
+++ b/webhook_handler.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/andrewslotin/doppelganger/git"
@@ -66,8 +67,9 @@ func (handler *WebhookHandler) UpdateRepo(req *http.Request) (repo *git.Reposito
 		return nil, err
 	}
 
-	if repo.Master != updateEvent.Ref {
-		log.Printf("skip push event to %s (mirrored ref %s, received %s)", repo.FullName, repo.Master, updateEvent.Ref)
+	updatedBranch := strings.TrimPrefix(updateEvent.Ref, "ref/heads/")
+	if repo.Master != updatedBranch {
+		log.Printf("skip push event to %s (mirrored ref %s, received %s)", repo.FullName, repo.Master, updatedBranch)
 		return repo, nil
 	}
 

--- a/webhook_handler.go
+++ b/webhook_handler.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/andrewslotin/doppelganger/git"
+)
+
+type WebhookHandler struct {
+	mirroredRepos git.MirrorService
+}
+
+func NewWebhookHandler(mirroredRepos git.MirrorService) *WebhookHandler {
+	return &WebhookHandler{
+		mirroredRepos: mirroredRepos,
+	}
+}
+
+func (handler *WebhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	startTime := time.Now()
+	defer req.Body.Close()
+
+	switch event := req.Header.Get("X-Github-Event"); event {
+	case "push":
+		switch repo, err := handler.UpdateRepo(req); err {
+		case nil:
+			log.Printf("updated %s [%s]", repo.FullName, time.Since(startTime))
+			fmt.Fprint(w, "OK")
+		case git.ErrorNotFound, git.ErrorNotMirrored:
+			http.Error(w, "Not found", http.StatusNotFound)
+		default:
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		}
+	default:
+		http.Error(w, fmt.Sprintf("Unsupported event %q", event), http.StatusBadRequest)
+	}
+}
+
+func (handler *WebhookHandler) UpdateRepo(req *http.Request) (repo *git.Repository, err error) {
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		log.Printf("failed to read request body (%s)", err)
+		return nil, err
+	}
+
+	var updateEvent struct {
+		Ref        string `json:"ref"`
+		Repository struct {
+			FullName string `json:"full_name"`
+		} `json:"repository"`
+	}
+
+	if err := json.Unmarshal(body, &updateEvent); err != nil {
+		log.Printf("failed to parse push event payload %s", string(body))
+		return nil, err
+	}
+
+	repo, err = handler.mirroredRepos.Get(updateEvent.Repository.FullName)
+	if err != nil {
+		log.Printf("failed to find mirrored copy of %s (%s)", updateEvent.Repository.FullName, err)
+		return nil, err
+	}
+
+	if repo.Master != updateEvent.Ref {
+		log.Printf("skip push event to %s (mirrored ref %s, received %s)", repo.FullName, repo.Master, updateEvent.Ref)
+		return repo, nil
+	}
+
+	return repo, handler.mirroredRepos.Update(repo.FullName)
+}


### PR DESCRIPTION
Create GitHub webhook to track changes automatically after mirroring a repository. Webhooks are being handled by `/apihook` endpoint and only have effect for push events to `master`. To skip hook setup append `notrack=1` to create mirror URL.
