### PR TITLE
Respond with HTTP 200 to GitHub pings

### DIFF
--- a/webhook_handler.go
+++ b/webhook_handler.go
@@ -27,6 +27,8 @@ func (handler *WebhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	defer req.Body.Close()
 
 	switch event := req.Header.Get("X-Github-Event"); event {
+	case "ping":
+		fmt.Fprint(w, "PONG")
 	case "push":
 		switch repo, err := handler.UpdateRepo(req); err {
 		case nil:


### PR DESCRIPTION
After webhook is created GitHub sends a ping event to check if the webhook endpoint exists.

https://developer.github.com/webhooks/#ping-event
