### PR TITLE
Handle repeated mirroring

### DIFF
--- a/git/github_repositories.go
+++ b/git/github_repositories.go
@@ -87,10 +87,6 @@ func (service *GithubRepositories) Get(fullName string) (*Repository, error) {
 	repoOwner, repoName := ParseRepositoryName(fullName)
 
 	githubRepo, response, err := service.client.Repositories.Get(repoOwner, repoName)
-	if err == nil {
-		err = api.CheckResponse(response.Response)
-	}
-
 	if err != nil {
 		if response.StatusCode == http.StatusNotFound {
 			return nil, ErrorNotFound
@@ -133,10 +129,7 @@ func (service *GithubRepositories) registerPushWebhook(owner, repo, cbURL string
 	*hook.Name = "web"
 	*hook.Active = true
 
-	_, response, err := service.client.Repositories.CreateHook(owner, repo, hook)
-	if err == nil {
-		err = api.CheckResponse(response.Response)
-	}
+	_, _, err := service.client.Repositories.CreateHook(owner, repo, hook)
 
 	return err
 }

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -70,7 +70,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 
 		if err := handler.SetupChangeTracking(w, req, repoName); err != nil {
 			log.Printf("failed to track changes for mirror %s: %s", repoName, err)
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			http.Error(w, "Failed to set up push web hook, please check logs for details", http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
- Check if webhook is already set up before fail
- Make the error message more informative to the user

Closes #6 
