### PR TITLE
Make golint and go vet happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.0.1
+VERSION = 1.0.2
 LDFLAGS = -X main.VERSION=$(VERSION) -X main.BUILD_DATE=$(shell date +%F)
 
 build: 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION = 1.0.2
-LDFLAGS = -X main.VERSION=$(VERSION) -X main.BUILD_DATE=$(shell date +%F)
+LDFLAGS = -X main.Version=$(VERSION) -X main.BuildDate=$(shell date +%F)
 
 build: 
 	@echo "Building v$(VERSION)"

--- a/git/commit.go
+++ b/git/commit.go
@@ -2,6 +2,7 @@ package git
 
 import "time"
 
+// Commit represents a single commit in Git repository.
 type Commit struct {
 	SHA     string
 	Message string

--- a/git/github_repositories.go
+++ b/git/github_repositories.go
@@ -10,12 +10,16 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// ErrorNotFound is returned by Get method if specified repository cannot be found.
 var ErrorNotFound = errors.New("not found")
 
+// GithubRepositories is a type intended to list and lookup GitHub repositories as well as setting webhooks.
 type GithubRepositories struct {
 	client *api.Client
 }
 
+// NewGithubRepositories creates and initializes a new instance of GithubRepositories. Provided token is
+// used to authorize requests to GitHub API and must be given "repo" or "public_repo" permissions.
 func NewGithubRepositories(token string) *GithubRepositories {
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: token,
@@ -27,6 +31,7 @@ func NewGithubRepositories(token string) *GithubRepositories {
 	}
 }
 
+// All returns a list of GitHub repositories accessible with provided API token.
 func (service *GithubRepositories) All() ([]*Repository, error) {
 	opts := &api.RepositoryListOptions{
 		ListOptions: api.ListOptions{
@@ -83,6 +88,7 @@ func (service *GithubRepositories) All() ([]*Repository, error) {
 	return allRepos, nil
 }
 
+// Get retireves GitHub repositories details and returns an instance of Repository containing last commit information.
 func (service *GithubRepositories) Get(fullName string) (*Repository, error) {
 	repoOwner, repoName := ParseRepositoryName(fullName)
 
@@ -111,6 +117,7 @@ func (service *GithubRepositories) Get(fullName string) (*Repository, error) {
 	return repo, nil
 }
 
+// Track sets up "push" event GitHub webhook to be sent to callbackURL.
 func (service *GithubRepositories) Track(fullName, callbackURL string) error {
 	owner, name := ParseRepositoryName(fullName)
 	return service.registerPushWebhook(owner, name, callbackURL)

--- a/git/mirrored_repositories.go
+++ b/git/mirrored_repositories.go
@@ -13,14 +13,18 @@ import (
 	"time"
 )
 
+// DefaultMaster is a default name for master branch.
 const DefaultMaster = "master"
 
 var (
 	gitCmd string
 
+	// ErrorNotMirrored is an error returned by Get if given repository does not exist.
 	ErrorNotMirrored = errors.New("mirror not found")
 )
 
+// MirroredRepositories is a type that is intended for maintaining local Git repository mirrors
+// located under the mirrorPath directory.
 type MirroredRepositories struct {
 	mirrorPath string
 }
@@ -32,16 +36,22 @@ func init() {
 	}
 }
 
+// NewMirroredRepositories creates and initializes an instance of MirroredRepositories reading and creating
+// repositories under path directory.
 func NewMirroredRepositories(path string) *MirroredRepositories {
 	return &MirroredRepositories{
 		mirrorPath: path,
 	}
 }
 
+// All recursively searches and returns a list of repositories under mirrorPath. Unlike Get, All returns
+// only basic information about Git repository, such as its name and the name of master branch.
 func (service *MirroredRepositories) All() ([]*Repository, error) {
 	return service.findGitRepos("")
 }
 
+// Get searches for a git repository in <mirrorPath>/<fullName> and returns the name of its name, master branch
+// and lastest commit. If specified directory does not exist or not a git repository ErrorNotMirrored is returned.
 func (service *MirroredRepositories) Get(fullName string) (*Repository, error) {
 	if !service.checkDirIsRepository(fullName) {
 		return nil, ErrorNotMirrored
@@ -53,10 +63,13 @@ func (service *MirroredRepositories) Get(fullName string) (*Repository, error) {
 	return repo, nil
 }
 
+// Create creates a local mirror of remote repository from gitURL by calling "git --mirror <gitURL> <fullName>".
 func (service *MirroredRepositories) Create(fullName, gitURL string) error {
 	return service.cloneMirror(gitURL, fullName)
 }
 
+// Update downloads latest changes from remote repository into a local mirror discarding any changes that were pushed
+// to mirror only. Update calls "git remote update" in <mirrorPath>/<fullName>.
 func (service *MirroredRepositories) Update(fullName string) error {
 	return service.updateRemote(fullName)
 }

--- a/git/repository.go
+++ b/git/repository.go
@@ -1,15 +1,24 @@
 package git
 
+// Repository represents single git repository.
 type Repository struct {
-	FullName    string
+	// Full repository name. For GitHub repositories it's set to <user>/<repo>,
+	// for local mirrors this is a path inside the mirror directory.
+	FullName string
+	// Description is optional and mostly applies to GitHub repositories.
 	Description string
-	Master      string
-	HTMLURL     string
-	GitURL      string
+	// The name of master branch.
+	Master string
+	// A link to repository on GitHub.
+	HTMLURL string
+	// Remote URL.
+	GitURL string
 
+	// The latest commit from master.
 	LatestMasterCommit *Commit
 }
 
+// Mirrored returns true if this is a local repository mirror.
 func (repo *Repository) Mirrored() bool {
 	return repo.HTMLURL == ""
 }

--- a/git/services.go
+++ b/git/services.go
@@ -1,10 +1,16 @@
 package git
 
+// RepositoryService is a type that wraps All and Get methods.
+//
+// Repository service is used to list and lookup repositories. Two implementations
 type RepositoryService interface {
 	All() ([]*Repository, error)
 	Get(name string) (*Repository, error)
 }
 
+// MirrorService is a type that extends RepositoryService adding two more methods: Create and Update.
+//
+// Mirror service is used to create new repository mirrors and update existing ones.
 type MirrorService interface {
 	RepositoryService
 
@@ -12,6 +18,9 @@ type MirrorService interface {
 	Update(name string) error
 }
 
+// TrackingService is a type that wraps Track method.
+//
+// Tracking service is used to set up tracking changes in a repository.
 type TrackingService interface {
 	Track(name, callbackURL string) error
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/andrewslotin/doppelganger/git"
 )
 
+// Version and BuildDate are used in help message and set by Makefile
 const (
 	Version   = "n/a"
 	BuildDate = "n/a"

--- a/main.go
+++ b/main.go
@@ -11,18 +11,20 @@ import (
 	"github.com/andrewslotin/doppelganger/git"
 )
 
+const (
+	Version   = "n/a"
+	BuildDate = "n/a"
+)
+
 var (
 	addr      = flag.String("addr", "", "Listen address")
 	port      = flag.Int("port", 8081, "Listen port")
 	mirrorDir = flag.String("mirror", filepath.Join(os.Getenv("GOPATH"), "src", "github.com"), "Mirrored repositories directory")
-
-	VERSION    = "n/a"
-	BUILD_DATE = "n/a"
 )
 
 func init() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Doppelganger, version %s, build date %s\n\nUsage: %s [OPTIONS]\n\nOptions:\n", VERSION, BUILD_DATE, os.Args[0])
+		fmt.Fprintf(os.Stderr, "Doppelganger, version %s, build date %s\n\nUsage: %s [OPTIONS]\n\nOptions:\n", Version, BuildDate, os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(2)
 	}

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -11,12 +11,23 @@ import (
 	"github.com/andrewslotin/doppelganger/git"
 )
 
+// MirrorHandler is a type that implements http.Handler interface and is used to handle requests to "/mirror".
+// An action that needs to be executed is defined by "action" form variable. Target repository is specified by its name passed in
+// request parameter "name".
+//
+//   // Create a new mirror of andrewslotin/doppelganger
+//   curl http://doppelganger/mirror?action=create&name=andrewslotin/doppelganger
+//   // Update an existing mirror of andrewslotin/doppelganger
+//   curl http://doppelganger/mirror?action=update&name=andrewslotin/doppelganger
+//   // Set up tracking of changes in andrewslotin/doppelganger
+//   curl http://doppelganger/mirror?action=track&name=andrewslotin/doppelganger
 type MirrorHandler struct {
 	githubRepos      git.RepositoryService
 	mirroredRepos    git.MirrorService
 	trackRepoService git.TrackingService
 }
 
+// NewMirrorHandler creates and initializes a new handler.
 func NewMirrorHandler(githubRepos git.RepositoryService, mirroredRepos git.MirrorService, trackingService git.TrackingService) *MirrorHandler {
 	return &MirrorHandler{
 		githubRepos:      githubRepos,
@@ -81,6 +92,8 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	}
 }
 
+// CreateMirror searches for a repository in githubRepos and creates its mirror.
+// If there is no such repository an HTTP 404 response will be sent.
 func (handler *MirrorHandler) CreateMirror(w http.ResponseWriter, repoName string) error {
 	switch repo, err := handler.githubRepos.Get(repoName); err {
 	case nil:
@@ -93,6 +106,8 @@ func (handler *MirrorHandler) CreateMirror(w http.ResponseWriter, repoName strin
 	}
 }
 
+// SetupChangeTracking searches for a repository in githubRepos and sets up changes tracker using trackingService.Track().
+// If there is no such repository an HTTP 404 response will be sent.
 func (handler *MirrorHandler) SetupChangeTracking(w http.ResponseWriter, req *http.Request, repoName string) error {
 	switch repo, err := handler.mirroredRepos.Get(repoName); err {
 	case nil:
@@ -105,6 +120,8 @@ func (handler *MirrorHandler) SetupChangeTracking(w http.ResponseWriter, req *ht
 	}
 }
 
+// UpdateMirror updates an existing mirror synchronizing its with source.
+// If there is no such repository an HTTP 404 response will be sent.
 func (handler *MirrorHandler) UpdateMirror(w http.ResponseWriter, repoName string) error {
 	switch repo, err := handler.mirroredRepos.Get(repoName); err {
 	case nil:

--- a/repo_handler.go
+++ b/repo_handler.go
@@ -19,7 +19,7 @@ type RepoHandler struct {
 	repositories git.RepositoryService
 }
 
-func NewRepoClient(repositoryService git.RepositoryService) *RepoHandler {
+func NewRepoHandler(repositoryService git.RepositoryService) *RepoHandler {
 	return &RepoHandler{
 		repositories: repositoryService,
 	}

--- a/repo_handler.go
+++ b/repo_handler.go
@@ -15,10 +15,14 @@ var (
 	newMirrorTemplate = template.Must(template.ParseFiles("templates/layout.html.template", "templates/repo/mirror.html.template"))
 )
 
+// RepoHandler is a type that implements http.Handler interface and is used by ReposHandler to handle single repository
+// requests containing "name" parameter. The value of this parameter is used to lookup the repository and render it using Show method.
+// If repository is not found a new mirror page is rendered instead using NewMirror.
 type RepoHandler struct {
 	repositories git.RepositoryService
 }
 
+// NewRepoHandler creates and initializes a new handler.
 func NewRepoHandler(repositoryService git.RepositoryService) *RepoHandler {
 	return &RepoHandler{
 		repositories: repositoryService,
@@ -64,10 +68,12 @@ func (handler *RepoHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 	}
 }
 
+// Show renders a repository page using templates/repo/show.html.template
 func (handler *RepoHandler) Show(w http.ResponseWriter, repo *git.Repository) error {
 	return repoTemplate.Execute(w, repo)
 }
 
+// NewMirror renders a new repository mirror page using templates/repo/mirror.html.template
 func (handler *RepoHandler) NewMirror(w http.ResponseWriter, repo *git.Repository) error {
 	return newMirrorTemplate.Execute(w, repo)
 }

--- a/repos_handler.go
+++ b/repos_handler.go
@@ -27,7 +27,7 @@ func (handler *ReposHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	startTime := time.Now()
 
 	if repoName := req.FormValue("repo"); repoName != "" {
-		NewRepoClient(handler.repositories).ServeHTTP(w, req)
+		NewRepoHandler(handler.repositories).ServeHTTP(w, req)
 		return
 	}
 

--- a/repos_handler.go
+++ b/repos_handler.go
@@ -33,7 +33,7 @@ func (handler *ReposHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 
 	repos, err := handler.repositories.All()
 	if err != nil {
-		log.Printf("failed to get repos (%s) %s", err, req)
+		log.Printf("failed to get repos (%s) %v", err, req)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/repos_handler.go
+++ b/repos_handler.go
@@ -13,10 +13,13 @@ var (
 	reposTemplate = template.Must(template.ParseFiles("templates/layout.html.template", "templates/repos/index.html.template"))
 )
 
+// ReposHandler is a type that implements http.Handler interface and is used to render repository lists.
+// Doppelganger uses ReposHandler to display both GitHub and local repositories.
 type ReposHandler struct {
 	repositories git.RepositoryService
 }
 
+// NewReposHandler creates and initializes a new handler.
 func NewReposHandler(repositoryService git.RepositoryService) *ReposHandler {
 	return &ReposHandler{
 		repositories: repositoryService,

--- a/webhook_handler.go
+++ b/webhook_handler.go
@@ -12,10 +12,15 @@ import (
 	"github.com/andrewslotin/doppelganger/git"
 )
 
+// WebhookHandler is a type that implements http.Handler interface and is used by HTTP server to handle GitHub webhooks sent to "/apihook".
+// Currently "ping" and "push" events are supported.
+//
+// For more details on webhooks see https://developer.github.com/webhooks/.
 type WebhookHandler struct {
 	mirroredRepos git.MirrorService
 }
 
+// NewWebhookHandler creates and initializes an instance of WebhookHandler.
 func NewWebhookHandler(mirroredRepos git.MirrorService) *WebhookHandler {
 	return &WebhookHandler{
 		mirroredRepos: mirroredRepos,
@@ -44,6 +49,7 @@ func (handler *WebhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	}
 }
 
+// UpdateRepo handles "push" event and updates existing GitHub repository mirrors synchronizing it with remote.
 func (handler *WebhookHandler) UpdateRepo(req *http.Request) (repo *git.Repository, err error) {
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {


### PR DESCRIPTION
Fix `fmt.Printf` issues and document all public types and methods to make `golint` and `go vet` pass.
