### PR TITLE
Move tests to a separate package

### DIFF
--- a/git/github_repositories.go
+++ b/git/github_repositories.go
@@ -9,17 +9,15 @@ import (
 	api "github.com/google/go-github/github"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
-)
 
-type tokenContextKey struct{}
-type clientContextKey struct{}
+	"github.com/andrewslotin/doppelganger/git/internal"
+)
 
 var (
 	// ErrorNotFound is returned by Get method if specified repository cannot be found.
 	ErrorNotFound = errors.New("not found")
 	// GithubToken is a context.Context key for Github auth token.
-	GithubToken tokenContextKey
-	httpClient  clientContextKey
+	GithubToken internal.TokenContextKey
 )
 
 // GithubRepositories is a type intended to list and lookup GitHub repositories as well as setting webhooks.
@@ -38,7 +36,7 @@ func NewGithubRepositories(ctx context.Context) (*GithubRepositories, error) {
 		return nil, errors.New("missing auth token")
 	}
 
-	if c, ok := ctx.Value(httpClient).(*api.Client); ok {
+	if c, ok := ctx.Value(internal.HttpClient).(*api.Client); ok {
 		return &GithubRepositories{
 			client: c,
 		}, nil

--- a/git/github_repositories_test.go
+++ b/git/github_repositories_test.go
@@ -1,4 +1,4 @@
-package git
+package git_test
 
 import (
 	"encoding/json"
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/andrewslotin/doppelganger/git"
 	"github.com/andrewslotin/doppelganger/git/internal"
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
@@ -18,29 +19,29 @@ import (
 )
 
 func TestParseRepositoryName(t *testing.T) {
-	owner, repo := ParseRepositoryName("test/me")
+	owner, repo := git.ParseRepositoryName("test/me")
 	assert.Equal(t, owner, "test")
 	assert.Equal(t, repo, "me")
 }
 
 func TestNewGithubRepositories_WithToken(t *testing.T) {
-	ctx := context.WithValue(context.Background(), GithubToken, "secret_token")
+	ctx := context.WithValue(context.Background(), git.GithubToken, "secret_token")
 
-	r, err := NewGithubRepositories(ctx)
+	r, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err, "Expected NewGithubRepositories to succeed")
 	assert.NotNil(t, r, "Expected NewGithubRepositories to return new instance")
 }
 
 func TestNewGithubRepositories_NoToken(t *testing.T) {
-	_, err := NewGithubRepositories(context.Background())
-	assert.Error(t, err, "Expected NewGithubRepositories to return an error")
+	_, err := git.NewGithubRepositories(context.Background())
+	assert.Error(t, err, "Expected git.NewGithubRepositories to return an error")
 }
 
 func TestNewGithubRepositories_EmptyToken(t *testing.T) {
-	ctx := context.WithValue(context.Background(), GithubToken, "")
+	ctx := context.WithValue(context.Background(), git.GithubToken, "")
 
-	_, err := NewGithubRepositories(ctx)
-	assert.Error(t, err, "Expected NewGithubRepositories to return an error")
+	_, err := git.NewGithubRepositories(ctx)
+	assert.Error(t, err, "Expected git.NewGithubRepositories to return an error")
 }
 
 func TestGithubRepositoriesAll_SingleRepository_DefaultFields(t *testing.T) {
@@ -54,7 +55,7 @@ func TestGithubRepositoriesAll_SingleRepository_DefaultFields(t *testing.T) {
                 }]`)
 	})
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	repos, err := githubRepos.All()
@@ -84,7 +85,7 @@ func TestGithubRepositoriesAll_SingleRepository_AllFields(t *testing.T) {
                 }]`)
 	})
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	repos, err := githubRepos.All()
@@ -113,7 +114,7 @@ func TestGithubRepositoriesAll_MultipleRepositories(t *testing.T) {
                 }]`)
 	})
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	repos, err := githubRepos.All()
@@ -135,7 +136,7 @@ func TestGithubRepositoriesAll_SkipWithoutGitURL(t *testing.T) {
                 }]`)
 	})
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	repos, err := githubRepos.All()
@@ -159,7 +160,7 @@ func TestGithubRepositoriesAll_SkipWithoutFullName(t *testing.T) {
                 }]`)
 	})
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	repos, err := githubRepos.All()
@@ -187,7 +188,7 @@ func TestGithubRepositoriesAll_HandlePagination(t *testing.T) {
 		fmt.Fprint(w, `[{"full_name": "user1/repo1","git_url": "git:git@github.com:user1/repo1.git"}]`)
 	})
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	repos, err := githubRepos.All()
@@ -225,7 +226,7 @@ func TestGithubRepositoriesGet_RepositoryExists(t *testing.T) {
 		}`)
 	})
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	repo, err := githubRepos.Get("user1/repo1")
@@ -239,11 +240,11 @@ func TestGithubRepositoriesGet_NotFound(t *testing.T) {
 	ctx, _, teardown := setup()
 	defer teardown()
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	_, err = githubRepos.Get("user1/repo1")
-	assert.Equal(t, err, ErrorNotFound)
+	assert.Equal(t, err, git.ErrorNotFound)
 }
 
 func TestGithubRepositoriesTrack(t *testing.T) {
@@ -267,7 +268,7 @@ func TestGithubRepositoriesTrack(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	githubRepos, err := NewGithubRepositories(ctx)
+	githubRepos, err := git.NewGithubRepositories(ctx)
 	require.NoError(t, err)
 
 	err = githubRepos.Track("user1/repo1", "http://example.com/cb")
@@ -283,7 +284,7 @@ func setup() (ctx context.Context, mux *http.ServeMux, teardownFn func()) {
 	client.BaseURL = url
 
 	ctx = context.Background()
-	ctx = context.WithValue(ctx, GithubToken, "secret_token")
+	ctx = context.WithValue(ctx, git.GithubToken, "secret_token")
 	ctx = context.WithValue(ctx, internal.HttpClient, client)
 
 	return ctx, mux, server.Close

--- a/git/github_repositories_test.go
+++ b/git/github_repositories_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/andrewslotin/doppelganger/git/internal"
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -283,7 +284,7 @@ func setup() (ctx context.Context, mux *http.ServeMux, teardownFn func()) {
 
 	ctx = context.Background()
 	ctx = context.WithValue(ctx, GithubToken, "secret_token")
-	ctx = context.WithValue(ctx, httpClient, client)
+	ctx = context.WithValue(ctx, internal.HttpClient, client)
 
 	return ctx, mux, server.Close
 }

--- a/git/internal/context_keys.go
+++ b/git/internal/context_keys.go
@@ -1,0 +1,7 @@
+package internal
+
+type TokenContextKey struct{}
+type ClientContextKey struct{}
+
+// To override http.Client in tests
+var HttpClient ClientContextKey

--- a/git/mirrored_repositories_test.go
+++ b/git/mirrored_repositories_test.go
@@ -1,4 +1,4 @@
-package git
+package git_test
 
 import (
 	"io/ioutil"
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andrewslotin/doppelganger/git"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -73,7 +74,7 @@ func TestMirroredRepositoriesAll(t *testing.T) {
 		cmd.On("CurrentBranch", path).Return(masterBranch)
 	}
 
-	mirroredRepos := NewMirroredRepositories(mirrorPath, cmd)
+	mirroredRepos := git.NewMirroredRepositories(mirrorPath, cmd)
 	mirrors, err := mirroredRepos.All()
 	require.NoError(t, err)
 	cmd.AssertExpectations(t)
@@ -91,7 +92,7 @@ func TestMirroredRepositoriesGet_MirrorExists(t *testing.T) {
 	cmd.On("CurrentBranch", "mirrors/a/b").Return("production")
 	cmd.On("LastCommit", "mirrors/a/b").Return("abc123", "Jon Doe", "HI MOM", "2016-04-23 16:12:39", nil)
 
-	mirroredRepos := NewMirroredRepositories("mirrors", cmd)
+	mirroredRepos := git.NewMirroredRepositories("mirrors", cmd)
 	repo, err := mirroredRepos.Get("a/b")
 	require.NoError(t, err)
 
@@ -112,18 +113,18 @@ func TestMirroredRepositoriesGet_NotMirrored(t *testing.T) {
 	cmd := &commandMock{}
 	cmd.On("IsRepository", "mirrors/a/b").Return(false)
 
-	mirroredRepos := NewMirroredRepositories("mirrors", cmd)
+	mirroredRepos := git.NewMirroredRepositories("mirrors", cmd)
 	_, err := mirroredRepos.Get("a/b")
 
 	cmd.AssertExpectations(t)
-	assert.Equal(t, err, ErrorNotMirrored)
+	assert.Equal(t, err, git.ErrorNotMirrored)
 }
 
 func TestMirroredRepositoriesCreate(t *testing.T) {
 	cmd := &commandMock{}
 	cmd.On("CloneMirror", "git@doppelganger:a/b", "mirrors/a/b").Return(nil)
 
-	mirroredRepos := NewMirroredRepositories("mirrors", cmd)
+	mirroredRepos := git.NewMirroredRepositories("mirrors", cmd)
 	require.NoError(t, mirroredRepos.Create("a/b", "git@doppelganger:a/b"))
 
 	cmd.AssertExpectations(t)
@@ -133,7 +134,7 @@ func TestMirroredRepositoriesUpdate(t *testing.T) {
 	cmd := &commandMock{}
 	cmd.On("UpdateRemote", "mirrors/a/b").Return(nil)
 
-	mirroredRepos := NewMirroredRepositories("mirrors", cmd)
+	mirroredRepos := git.NewMirroredRepositories("mirrors", cmd)
 	require.NoError(t, mirroredRepos.Update("a/b"))
 
 	cmd.AssertExpectations(t)


### PR DESCRIPTION
To keep package interface clean all tests from `github.com/andrewslotin/doppelganger/git` were moved to `git_test` package.
