### PR TITLE
Resourcify routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: go
 go:
-  - 1.5
-  - 1.5.1
   - 1.6
   - 1.6.1
   - 1.6.2
+  - 1.7beta2
   - tip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ go:
   - tip
 
 install:
- - go get github.com/stretchr/testify github.com/google/go-github/github golang.org/x/net/context golang.org/x/oauth2
+ - go get github.com/stretchr/testify

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,6 @@ clean:
 
 PACKAGES := $$(go list ./... | grep -v /vendor/ )
 test:
-	GO15VENDOREXPERIMENT=1 go test $(PACKAGES)
+	go test $(PACKAGES)
 
 .PHONY: build test release clean

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ clean:
 	go clean ./...
 	rm doppelganger-$(VERSION)_*.tar.gz 2>/dev/null || true
 
+PACKAGES := $$(go list ./... | grep -v /vendor/ )
 test:
-	go test github.com/andrewslotin/doppelganger/git
+	GO15VENDOREXPERIMENT=1 go test $(PACKAGES)
 
-.PHONY: clean
+.PHONY: build test release clean

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -135,7 +135,16 @@ func (handler *MirrorHandler) UpdateMirror(w http.ResponseWriter, repoName strin
 }
 
 func (handler *MirrorHandler) redirectToRepository(w http.ResponseWriter, req *http.Request, repoName string) {
-	http.Redirect(w, req, fmt.Sprintf("/mirrored?repo=%s", url.QueryEscape(repoName)), http.StatusSeeOther)
+	http.Redirect(w, req, "/mirror/"+repoName, http.StatusSeeOther)
+}
+
+func (handler *MirrorHandler) fetchRepoFromRequest(req *http.Request) (string, bool) {
+	owner, repo := req.URL.Query().Get(":owner"), req.URL.Query().Get(":repo")
+	if owner != "" && repo != "" {
+		return "", false
+	}
+
+	return owner + "/" + repo, true
 }
 
 func apiHookURL(host string, isSSL bool) *url.URL {

--- a/repos_handler.go
+++ b/repos_handler.go
@@ -29,11 +29,6 @@ func NewReposHandler(repositoryService git.RepositoryService) *ReposHandler {
 func (handler *ReposHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	startTime := time.Now()
 
-	if repoName := req.FormValue("repo"); repoName != "" {
-		NewRepoHandler(handler.repositories).ServeHTTP(w, req)
-		return
-	}
-
 	repos, err := handler.repositories.All()
 	if err != nil {
 		log.Printf("failed to get repos (%s) %v", err, req)

--- a/templates/repo/mirror.html.template
+++ b/templates/repo/mirror.html.template
@@ -12,8 +12,8 @@
   <div class="row">
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
       <ul class="nav nav-pills">
-        <li role="presentation"><a href="/?repo={{ .FullName | urlquery }}">Source repository</a></li>
-        <li role="presentation" class="active"><a href="/mirrored?repo={{ .FullName | urlquery }}">Mirrored copy</a></li>
+        <li role="presentation"><a href="/{{ .FullName }}">Source repository</a></li>
+        <li role="presentation" class="active"><a href="/mirror/{{ .FullName }}">Mirrored copy</a></li>
         <li role="presentation"><a href="/">Back to GitHub repositories list</a></li>
       </ul>
     </div>
@@ -27,7 +27,7 @@
         GitHub repository <samp>{{ .FullName }}</samp> was not mirrored yet. After you click "Proceed" a bare copy will be created within the mirror directory.
       </p>
       <p>
-        You can always synchronize your mirrored copy by clicking "Sync" button at <a href="/mirrored?repo{{ .FullName | urlquery }}">mirrored copy page</a>. Besides that a GitHub webhook will be created and every time you push to the default branch (usually <samp>master</samp>) the copy will be updated as well. You might want to configure your reverse proxy to restrict access to <code>/apihook</code> from GitHub IPs only.
+        You can always synchronize your mirrored copy by clicking "Sync" button at <a href="/mirror/{{ .FullName }}">mirrored copy page</a>. Besides that a GitHub webhook will be created and every time you push to the default branch (usually <samp>master</samp>) the copy will be updated as well. You might want to configure your reverse proxy to restrict access to <code>/apihook</code> from GitHub IPs only.
       </p>
       <div class="alert alert-info" role="alert">
         <strong>Note:</strong> any changes pushed to the mirror repository will be discarded next time the source repository is updated.

--- a/templates/repo/show.html.template
+++ b/templates/repo/show.html.template
@@ -17,11 +17,11 @@
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
       <ul class="nav nav-pills">
         {{ if .Mirrored }}
-        <li role="presentation"><a href="/?repo={{ .FullName | urlquery }}">Source repository</a></li>
-        <li role="presentation" class="active"><a href="/mirrored?repo={{ .FullName | urlquery }}">Mirrored copy</a></li>
+        <li role="presentation"><a href="/{{ .FullName }}">Source repository</a></li>
+        <li role="presentation" class="active"><a href="/mirror/{{ .FullName }}">Mirrored copy</a></li>
         {{ else }}
-        <li role="presentation" class="active"><a href="/?repo={{ .FullName | urlquery }}">Source repository</a></li>
-        <li role="presentation"><a href="/mirrored?repo={{ .FullName | urlquery }}">Mirrored copy</a></li>
+        <li role="presentation" class="active"><a href="/{{ .FullName }}">Source repository</a></li>
+        <li role="presentation"><a href="/mirror/{{ .FullName }}">Mirrored copy</a></li>
         <li role="presentation"><a href="{{ .HTMLURL }}">View on GitHub</a></li>
         {{ end }}
         <li role="presentation"><a href="/">Back to GitHub repositories list</a></li>
@@ -52,9 +52,10 @@
       </p>
       <p>
         Add mirror as a new remote to an already existing repository and use set it as upstream for local <samp>master<samp>:
-        <pre>git remote add mirror git@&lt;mirror-host&gt;:&lt;mirror-dir&gt;/{{ .FullName }}.git
-  git branch --unset-upstream master
-  git branch --set-upstream master mirror/master</pre>
+        <pre>
+git remote add mirror git@&lt;mirror-host&gt;:&lt;mirror-dir&gt;/{{ .FullName }}.git
+git branch --unset-upstream master
+git branch --set-upstream master mirror/master</pre>
       </p>
     </div>
   </div>

--- a/templates/repos/index.html.template
+++ b/templates/repos/index.html.template
@@ -10,8 +10,12 @@
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
       <div id="repositories-list" class="list-group">
         {{ range . }}
-          <a href="?repo={{ .FullName | urlquery }}" class="list-group-item">
-            <h4>{{ .FullName }}</h4>
+          {{ if .Mirrored }}
+            <a href="/mirror/{{ .FullName }}" class="list-group-item">
+          {{ else }}
+            <a href="/{{ .FullName }}" class="list-group-item">
+          {{ end }}
+          <h4>{{ .FullName }}</h4>
             {{ if .Description }}<p class="list-group-item-text">{{ .Description }}</p>{{ end }}
           </a>
         {{ else }}

--- a/vendor/github.com/bmizerany/pat/README.md
+++ b/vendor/github.com/bmizerany/pat/README.md
@@ -1,0 +1,82 @@
+# pat (formerly pat.go) - A Sinatra style pattern muxer for Go's net/http library
+
+[![GoDoc](https://godoc.org/github.com/bmizerany/pat?status.svg)](https://godoc.org/github.com/bmizerany/pat) 
+
+## INSTALL
+
+	$ go get github.com/bmizerany/pat
+
+## USE
+
+```go
+package main
+
+import (
+	"io"
+	"net/http"
+	"github.com/bmizerany/pat"
+	"log"
+)
+
+// hello world, the web server
+func HelloServer(w http.ResponseWriter, req *http.Request) {
+	io.WriteString(w, "hello, "+req.URL.Query().Get(":name")+"!\n")
+}
+
+func main() {
+	m := pat.New()
+	m.Get("/hello/:name", http.HandlerFunc(HelloServer))
+
+	// Register this pat with the default serve mux so that other packages
+	// may also be exported. (i.e. /debug/pprof/*)
+	http.Handle("/", m)
+	err := http.ListenAndServe(":12345", nil)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}
+```
+
+It's that simple.
+
+For more information, see:
+http://godoc.org/github.com/bmizerany/pat
+
+## CONTRIBUTORS
+
+* Alexis Svinartchouk (@zvin)
+* Blake Mizerany (@bmizerany)
+* Brian Ketelsen (@bketelsen)
+* Bryan Matsuo (@bmatsuo)
+* Caleb Spare (@cespare)
+* Evan Shaw (@edsrzf)
+* Gary Burd (@garyburd)
+* George Rogers (@georgerogers42)
+* Keith Rarick (@kr)
+* Matt Williams (@mattyw)
+* Mike Stipicevic (@wickedchicken)
+* Nick Saika (@nesv)
+* Timothy Cyrus (@tcyrus)
+* binqin (@binku87)
+
+## LICENSE
+
+Copyright (C) 2012 by Keith Rarick, Blake Mizerany
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/bmizerany/pat/mux.go
+++ b/vendor/github.com/bmizerany/pat/mux.go
@@ -1,0 +1,310 @@
+// Package pat implements a simple URL pattern muxer
+package pat
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// PatternServeMux is an HTTP request multiplexer. It matches the URL of each
+// incoming request against a list of registered patterns with their associated
+// methods and calls the handler for the pattern that most closely matches the
+// URL.
+//
+// Pattern matching attempts each pattern in the order in which they were
+// registered.
+//
+// Patterns may contain literals or captures. Capture names start with a colon
+// and consist of letters A-Z, a-z, _, and 0-9. The rest of the pattern
+// matches literally. The portion of the URL matching each name ends with an
+// occurrence of the character in the pattern immediately following the name,
+// or a /, whichever comes first. It is possible for a name to match the empty
+// string.
+//
+// Example pattern with one capture:
+//   /hello/:name
+// Will match:
+//   /hello/blake
+//   /hello/keith
+// Will not match:
+//   /hello/blake/
+//   /hello/blake/foo
+//   /foo
+//   /foo/bar
+//
+// Example 2:
+//    /hello/:name/
+// Will match:
+//   /hello/blake/
+//   /hello/keith/foo
+//   /hello/blake
+//   /hello/keith
+// Will not match:
+//   /foo
+//   /foo/bar
+//
+// A pattern ending with a slash will add an implicit redirect for its non-slash
+// version. For example: Get("/foo/", handler) also registers
+// Get("/foo", handler) as a redirect. You may override it by registering
+// Get("/foo", anotherhandler) before the slash version.
+//
+// Retrieve the capture from the r.URL.Query().Get(":name") in a handler (note
+// the colon). If a capture name appears more than once, the additional values
+// are appended to the previous values (see
+// http://golang.org/pkg/net/url/#Values)
+//
+// A trivial example server is:
+//
+//	package main
+//
+//	import (
+//		"io"
+//		"net/http"
+//		"github.com/bmizerany/pat"
+//		"log"
+//	)
+//
+//	// hello world, the web server
+//	func HelloServer(w http.ResponseWriter, req *http.Request) {
+//		io.WriteString(w, "hello, "+req.URL.Query().Get(":name")+"!\n")
+//	}
+//
+//	func main() {
+//		m := pat.New()
+//		m.Get("/hello/:name", http.HandlerFunc(HelloServer))
+//
+//		// Register this pat with the default serve mux so that other packages
+//		// may also be exported. (i.e. /debug/pprof/*)
+//		http.Handle("/", m)
+//		err := http.ListenAndServe(":12345", nil)
+//		if err != nil {
+//			log.Fatal("ListenAndServe: ", err)
+//		}
+//	}
+//
+// When "Method Not Allowed":
+//
+// Pat knows what methods are allowed given a pattern and a URI. For
+// convenience, PatternServeMux will add the Allow header for requests that
+// match a pattern for a method other than the method requested and set the
+// Status to "405 Method Not Allowed".
+//
+// If the NotFound handler is set, then it is used whenever the pattern doesn't
+// match the request path for the current method (and the Allow header is not
+// altered).
+type PatternServeMux struct {
+	// NotFound, if set, is used whenever the request doesn't match any
+	// pattern for its method. NotFound should be set before serving any
+	// requests.
+	NotFound http.Handler
+	handlers map[string][]*patHandler
+}
+
+// New returns a new PatternServeMux.
+func New() *PatternServeMux {
+	return &PatternServeMux{handlers: make(map[string][]*patHandler)}
+}
+
+// ServeHTTP matches r.URL.Path against its routing table using the rules
+// described above.
+func (p *PatternServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, ph := range p.handlers[r.Method] {
+		if params, ok := ph.try(r.URL.Path); ok {
+			if len(params) > 0 && !ph.redirect {
+				r.URL.RawQuery = url.Values(params).Encode() + "&" + r.URL.RawQuery
+			}
+			ph.ServeHTTP(w, r)
+			return
+		}
+	}
+
+	if p.NotFound != nil {
+		p.NotFound.ServeHTTP(w, r)
+		return
+	}
+
+	allowed := make([]string, 0, len(p.handlers))
+	for meth, handlers := range p.handlers {
+		if meth == r.Method {
+			continue
+		}
+
+		for _, ph := range handlers {
+			if _, ok := ph.try(r.URL.Path); ok {
+				allowed = append(allowed, meth)
+			}
+		}
+	}
+
+	if len(allowed) == 0 {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Add("Allow", strings.Join(allowed, ", "))
+	http.Error(w, "Method Not Allowed", 405)
+}
+
+// Head will register a pattern with a handler for HEAD requests.
+func (p *PatternServeMux) Head(pat string, h http.Handler) {
+	p.Add("HEAD", pat, h)
+}
+
+// Get will register a pattern with a handler for GET requests.
+// It also registers pat for HEAD requests. If this needs to be overridden, use
+// Head before Get with pat.
+func (p *PatternServeMux) Get(pat string, h http.Handler) {
+	p.Add("HEAD", pat, h)
+	p.Add("GET", pat, h)
+}
+
+// Post will register a pattern with a handler for POST requests.
+func (p *PatternServeMux) Post(pat string, h http.Handler) {
+	p.Add("POST", pat, h)
+}
+
+// Put will register a pattern with a handler for PUT requests.
+func (p *PatternServeMux) Put(pat string, h http.Handler) {
+	p.Add("PUT", pat, h)
+}
+
+// Del will register a pattern with a handler for DELETE requests.
+func (p *PatternServeMux) Del(pat string, h http.Handler) {
+	p.Add("DELETE", pat, h)
+}
+
+// Options will register a pattern with a handler for OPTIONS requests.
+func (p *PatternServeMux) Options(pat string, h http.Handler) {
+	p.Add("OPTIONS", pat, h)
+}
+
+// Patch will register a pattern with a handler for PATCH requests.
+func (p *PatternServeMux) Patch(pat string, h http.Handler) {
+	p.Add("PATCH", pat, h)
+}
+
+// Add will register a pattern with a handler for meth requests.
+func (p *PatternServeMux) Add(meth, pat string, h http.Handler) {
+	p.add(meth, pat, h, false)
+}
+
+func (p *PatternServeMux) add(meth, pat string, h http.Handler, redirect bool) {
+	handlers := p.handlers[meth]
+	for _, p1 := range handlers {
+		if p1.pat == pat {
+			return // found existing pattern; do nothing
+		}
+	}
+	handler := &patHandler{
+		pat:      pat,
+		Handler:  h,
+		redirect: redirect,
+	}
+	p.handlers[meth] = append(handlers, handler)
+
+	n := len(pat)
+	if n > 0 && pat[n-1] == '/' {
+		p.add(meth, pat[:n-1], http.HandlerFunc(addSlashRedirect), true)
+	}
+}
+
+func addSlashRedirect(w http.ResponseWriter, r *http.Request) {
+	u := *r.URL
+	u.Path += "/"
+	http.Redirect(w, r, u.String(), http.StatusMovedPermanently)
+}
+
+// Tail returns the trailing string in path after the final slash for a pat ending with a slash.
+//
+// Examples:
+//
+//	Tail("/hello/:title/", "/hello/mr/mizerany") == "mizerany"
+//	Tail("/:a/", "/x/y/z")                       == "y/z"
+//
+func Tail(pat, path string) string {
+	var i, j int
+	for i < len(path) {
+		switch {
+		case j >= len(pat):
+			if pat[len(pat)-1] == '/' {
+				return path[i:]
+			}
+			return ""
+		case pat[j] == ':':
+			var nextc byte
+			_, nextc, j = match(pat, isAlnum, j+1)
+			_, _, i = match(path, matchPart(nextc), i)
+		case path[i] == pat[j]:
+			i++
+			j++
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+type patHandler struct {
+	pat string
+	http.Handler
+	redirect bool
+}
+
+func (ph *patHandler) try(path string) (url.Values, bool) {
+	p := make(url.Values)
+	var i, j int
+	for i < len(path) {
+		switch {
+		case j >= len(ph.pat):
+			if ph.pat != "/" && len(ph.pat) > 0 && ph.pat[len(ph.pat)-1] == '/' {
+				return p, true
+			}
+			return nil, false
+		case ph.pat[j] == ':':
+			var name, val string
+			var nextc byte
+			name, nextc, j = match(ph.pat, isAlnum, j+1)
+			val, _, i = match(path, matchPart(nextc), i)
+			p.Add(":"+name, val)
+		case path[i] == ph.pat[j]:
+			i++
+			j++
+		default:
+			return nil, false
+		}
+	}
+	if j != len(ph.pat) {
+		return nil, false
+	}
+	return p, true
+}
+
+func matchPart(b byte) func(byte) bool {
+	return func(c byte) bool {
+		return c != b && c != '/'
+	}
+}
+
+func match(s string, f func(byte) bool, i int) (matched string, next byte, j int) {
+	j = i
+	for j < len(s) && f(s[j]) {
+		j++
+	}
+	if j < len(s) {
+		next = s[j]
+	}
+	return s[i:j], next, j
+}
+
+func isAlpha(ch byte) bool {
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
+}
+
+func isDigit(ch byte) bool {
+	return '0' <= ch && ch <= '9'
+}
+
+func isAlnum(ch byte) bool {
+	return isAlpha(ch) || isDigit(ch)
+}


### PR DESCRIPTION
Instead of passing repository as `repo` parameter make it a part of URL. As a result to switch from GitHub to Doppelganger user only needs to change the host part.

New routing scheme:
- `http://<doppelganger>/<owner>/<repo>` — open `github.com/<owner>/<repo>` in Doppelganger.
- `http://<doppelganger>/mirror/<owner>/<repo>` — mirrored copy of `github.com/<owner>/<repo>`.
- `http://<doppelganger>/mirror` — all mirrored copies for this Doppelganger instance.
- `http://<doppelganger>/` — all repositories accessible to this Doppelganger.
