### PR TITLE
When creating a mirror fetch repo name from form value

### DIFF
--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -138,12 +138,8 @@ func (handler *MirrorHandler) redirectToRepository(w http.ResponseWriter, req *h
 }
 
 func (handler *MirrorHandler) fetchRepoFromRequest(req *http.Request) (string, bool) {
-	owner, repo := req.URL.Query().Get(":owner"), req.URL.Query().Get(":repo")
-	if owner != "" && repo != "" {
-		return "", false
-	}
-
-	return owner + "/" + repo, true
+	fullRepoName := req.FormValue("repo")
+	return fullRepoName, fullRepoName != ""
 }
 
 func apiHookURL(host string, isSSL bool) *url.URL {


### PR DESCRIPTION
In Doppelganger v1.0.3 mirror handler was expecting repository name to be a part of the route, which is not the case. This PR brings back reading the repo name from `repo` parameter when creating or updating a mirror.
