### PR TITLE
Mirrored first

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -16,6 +16,10 @@ body {
     background-color: #ffffff;
 }
 
+.nav.nav-pills {
+    margin-bottom: 1.5em;
+}
+
 #repositories-list .list-group-item {
     margin-top: 0.5em;
     border: none;

--- a/main.go
+++ b/main.go
@@ -72,9 +72,9 @@ func main() {
 		http.ServeFile(w, r, "./assets/favicon.ico")
 	}))
 
-	mux.Get("/:owner/:repo", NewRepoHandler(repositoryService))
+	mux.Get("/:owner/:repo", NewRepoHandler(mirroredRepositoryService))
 	mux.Get("/", NewReposHandler(mirroredRepositoryService))
-	mux.Get("/mirror/:owner/:repo", NewRepoHandler(mirroredRepositoryService))
+	mux.Get("/src/:owner/:repo", NewRepoHandler(repositoryService))
 	mux.Get("/src/", NewReposHandler(repositoryService))
 	mux.Post("/mirror", NewMirrorHandler(repositoryService, mirroredRepositoryService, repositoryService))
 	mux.Get("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("./assets"))))

--- a/main.go
+++ b/main.go
@@ -73,9 +73,9 @@ func main() {
 	}))
 
 	mux.Get("/:owner/:repo", NewRepoHandler(mirroredRepositoryService))
-	mux.Get("/", NewReposHandler(mirroredRepositoryService))
+	mux.Get("/", NewReposHandler(mirroredRepositoryService, true))
 	mux.Get("/src/:owner/:repo", NewRepoHandler(repositoryService))
-	mux.Get("/src/", NewReposHandler(repositoryService))
+	mux.Get("/src/", NewReposHandler(repositoryService, false))
 	mux.Post("/mirror", NewMirrorHandler(repositoryService, mirroredRepositoryService, repositoryService))
 	mux.Get("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("./assets"))))
 

--- a/main.go
+++ b/main.go
@@ -72,11 +72,11 @@ func main() {
 		http.ServeFile(w, r, "./assets/favicon.ico")
 	}))
 
-	mux.Get("/", NewReposHandler(repositoryService))
 	mux.Get("/:owner/:repo", NewRepoHandler(repositoryService))
-	mux.Get("/mirror", NewReposHandler(mirroredRepositoryService))
-	mux.Post("/mirror", NewMirrorHandler(repositoryService, mirroredRepositoryService, repositoryService))
+	mux.Get("/", NewReposHandler(mirroredRepositoryService))
 	mux.Get("/mirror/:owner/:repo", NewRepoHandler(mirroredRepositoryService))
+	mux.Get("/src/", NewReposHandler(repositoryService))
+	mux.Post("/mirror", NewMirrorHandler(repositoryService, mirroredRepositoryService, repositoryService))
 	mux.Get("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("./assets"))))
 
 	// GitHub webhooks

--- a/mirror_handler.go
+++ b/mirror_handler.go
@@ -49,7 +49,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	case "create":
 		if err := handler.CreateMirror(w, repoName); err != nil {
 			if err == git.ErrorNotFound {
-				WriteNotFoundPage(w, fmt.Sprintf("No such GitHub repository: %s", repoName), "/")
+				WriteNotFoundPage(w, fmt.Sprintf("No such GitHub repository: %s", repoName), "/src/")
 			} else {
 				log.Printf("failed to create mirror %s: %s", repoName, err)
 				WriteErrorPage(w, UserError{Message: "Internal server error", BackURL: req.Referer(), OriginalError: err}, http.StatusInternalServerError)
@@ -61,7 +61,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		if req.FormValue("notrack") == "" && handler.trackRepoService != nil {
 			if err := handler.SetupChangeTracking(w, req, repoName); err != nil {
 				if err == git.ErrorNotMirrored {
-					WriteNotFoundPage(w, fmt.Sprintf("Repository %s was not mirrored yet", repoName), "/"+repoName)
+					WriteNotFoundPage(w, fmt.Sprintf("Repository %s was not mirrored yet", repoName), "/src/"+repoName)
 				} else {
 					log.Printf("failed to track changes for mirror %s: %s", repoName, err)
 					WriteErrorPage(w, UserError{Message: "Failed to set up push web hook, please check logs for details", BackURL: req.Referer(), OriginalError: err}, http.StatusInternalServerError)
@@ -76,7 +76,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	case "update":
 		if err := handler.UpdateMirror(w, repoName); err != nil {
 			if err == git.ErrorNotMirrored {
-				WriteNotFoundPage(w, fmt.Sprintf("Repository %s was not mirrored yet", repoName), "/"+repoName)
+				WriteNotFoundPage(w, fmt.Sprintf("Repository %s was not mirrored yet", repoName), "/src/"+repoName)
 			} else {
 				log.Printf("failed to update mirror %s: %s", repoName, err)
 				WriteErrorPage(w, UserError{Message: "Internal server error", BackURL: req.Referer(), OriginalError: err}, http.StatusInternalServerError)
@@ -95,7 +95,7 @@ func (handler *MirrorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 
 		if err := handler.SetupChangeTracking(w, req, repoName); err != nil {
 			if err == git.ErrorNotMirrored {
-				WriteNotFoundPage(w, fmt.Sprintf("Repository %s was not mirrored yet", repoName), "/"+repoName)
+				WriteNotFoundPage(w, fmt.Sprintf("Repository %s was not mirrored yet", repoName), "/src/"+repoName)
 			} else {
 				log.Printf("failed to track changes for mirror %s: %s", repoName, err)
 				WriteErrorPage(w, UserError{Message: "Failed to set up push web hook, please check logs for details", BackURL: req.Referer(), OriginalError: err}, http.StatusInternalServerError)
@@ -142,7 +142,7 @@ func (handler *MirrorHandler) UpdateMirror(w http.ResponseWriter, repoName strin
 }
 
 func (handler *MirrorHandler) redirectToRepository(w http.ResponseWriter, req *http.Request, repoName string) {
-	http.Redirect(w, req, "/mirror/"+repoName, http.StatusSeeOther)
+	http.Redirect(w, req, "/"+repoName, http.StatusSeeOther)
 }
 
 func (handler *MirrorHandler) fetchRepoFromRequest(req *http.Request) (string, bool) {

--- a/repos_handler.go
+++ b/repos_handler.go
@@ -38,7 +38,11 @@ func (handler *ReposHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	if err := reposTemplate.Execute(w, repos); err != nil {
+	values := struct {
+		Repositories []*git.Repository
+		Mirrors      bool
+	}{repos, handler.mirrors}
+	if err := reposTemplate.Execute(w, values); err != nil {
 		log.Printf("failed to render repos/index with %d entries (%s)", len(repos), err)
 		WriteErrorPage(w, UserError{Message: "Internal server error", BackURL: req.Referer(), OriginalError: err}, http.StatusInternalServerError)
 	} else {

--- a/repos_handler.go
+++ b/repos_handler.go
@@ -17,12 +17,14 @@ var (
 // Doppelganger uses ReposHandler to display both GitHub and local repositories.
 type ReposHandler struct {
 	repositories git.RepositoryService
+	mirrors      bool
 }
 
 // NewReposHandler creates and initializes a new handler.
-func NewReposHandler(repositoryService git.RepositoryService) *ReposHandler {
+func NewReposHandler(repositoryService git.RepositoryService, mirrors bool) *ReposHandler {
 	return &ReposHandler{
 		repositories: repositoryService,
+		mirrors:      mirrors,
 	}
 }
 

--- a/templates/errors/internal_error.html.template
+++ b/templates/errors/internal_error.html.template
@@ -15,7 +15,7 @@
         {{ if .BackURL }}
           <li role="presentation"><a href="/{{ .BackURL }}">Go back</a></li>
         {{ end }}
-        <li role="presentation"><a href="/">GitHub repositories list</a></li>
+        <li role="presentation"><a href="/src/">GitHub repositories list</a></li>
       </ul>
     </div>
   </div>

--- a/templates/errors/internal_error.html.template
+++ b/templates/errors/internal_error.html.template
@@ -15,7 +15,8 @@
         {{ if .BackURL }}
           <li role="presentation"><a href="/{{ .BackURL }}">Go back</a></li>
         {{ end }}
-        <li role="presentation"><a href="/src/">GitHub repositories list</a></li>
+        <li role="presentation"><a href="/">Mirrored repositories</a></li>
+        <li role="presentation"><a href="/src/">GitHub repositories</a></li>
       </ul>
     </div>
   </div>

--- a/templates/errors/not_found.html.template
+++ b/templates/errors/not_found.html.template
@@ -11,6 +11,15 @@
 
   <div class="row">
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
+      <ul class="nav nav-pills">
+        <li role="presentation"><a href="/">Mirrored repositories</a></li>
+        <li role="presentation"><a href="/src/">GitHub repositories</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
       <h3>Page not found</h3>
       <p>{{ .Message }}</p>
       {{ if .BackURL }}

--- a/templates/layout.html.template
+++ b/templates/layout.html.template
@@ -38,7 +38,7 @@
     <script type="text/javascript" src="/assets/js/jquery.js"></script>
     <script type="text/javascript" src="/assets/js/bootstrap.js"></script>
 
-    <div class="content">
+    <div class="content container">
       {{ block "content" . }}{{ end }}
     </div>
 

--- a/templates/repo/mirror.html.template
+++ b/templates/repo/mirror.html.template
@@ -14,7 +14,8 @@
       <ul class="nav nav-pills">
         <li role="presentation" class="active"><a href="/{{ .FullName }}">Mirrored copy</a></li>
         <li role="presentation"><a href="/src/{{ .FullName }}">Source repository</a></li>
-        <li role="presentation"><a href="/src/">GitHub repositories list</a></li>
+        <li role="presentation"><a href="/">Mirrored repositories</a></li>
+        <li role="presentation"><a href="/src/">GitHub repositories</a></li>
       </ul>
     </div>
   </div>

--- a/templates/repo/mirror.html.template
+++ b/templates/repo/mirror.html.template
@@ -12,8 +12,8 @@
   <div class="row">
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
       <ul class="nav nav-pills">
-        <li role="presentation"><a href="/{{ .FullName }}">Source repository</a></li>
-        <li role="presentation" class="active"><a href="/mirror/{{ .FullName }}">Mirrored copy</a></li>
+        <li role="presentation" class="active"><a href="/{{ .FullName }}">Mirrored copy</a></li>
+        <li role="presentation"><a href="/src/{{ .FullName }}">Source repository</a></li>
         <li role="presentation"><a href="/src/">GitHub repositories list</a></li>
       </ul>
     </div>
@@ -27,7 +27,7 @@
         GitHub repository <samp>{{ .FullName }}</samp> was not mirrored yet. After you click "Proceed" a bare copy will be created within the mirror directory.
       </p>
       <p>
-        You can always synchronize your mirrored copy by clicking "Sync" button at <a href="/mirror/{{ .FullName }}">mirrored copy page</a>. Besides that a GitHub webhook will be created and every time you push to the default branch (usually <samp>master</samp>) the copy will be updated as well. You might want to configure your reverse proxy to restrict access to <code>/apihook</code> from GitHub IPs only.
+        You can always synchronize your mirrored copy by clicking "Sync" button at <a href="/{{ .FullName }}">mirrored copy page</a>. Besides that a GitHub webhook will be created and every time you push to the default branch (usually <samp>master</samp>) the copy will be updated as well. You might want to configure your reverse proxy to restrict access to <code>/apihook</code> from GitHub IPs only.
       </p>
       <div class="alert alert-info" role="alert">
         <strong>Note:</strong> any changes pushed to the mirror repository will be discarded next time the source repository is updated.

--- a/templates/repo/mirror.html.template
+++ b/templates/repo/mirror.html.template
@@ -14,7 +14,7 @@
       <ul class="nav nav-pills">
         <li role="presentation"><a href="/{{ .FullName }}">Source repository</a></li>
         <li role="presentation" class="active"><a href="/mirror/{{ .FullName }}">Mirrored copy</a></li>
-        <li role="presentation"><a href="/">Back to GitHub repositories list</a></li>
+        <li role="presentation"><a href="/src/">GitHub repositories list</a></li>
       </ul>
     </div>
   </div>

--- a/templates/repo/show.html.template
+++ b/templates/repo/show.html.template
@@ -24,7 +24,8 @@
         <li role="presentation" class="active"><a href="/src/{{ .FullName }}">Source repository</a></li>
         <li role="presentation"><a href="{{ .HTMLURL }}">View on GitHub</a></li>
         {{ end }}
-        <li role="presentation"><a href="/src/">GitHub repositories list</a></li>
+        <li role="presentation"><a href="/">Mirrored repositories</a></li>
+        <li role="presentation"><a href="/src/">GitHub repositories</a></li>
       </ul>
     </div>
   </div>

--- a/templates/repo/show.html.template
+++ b/templates/repo/show.html.template
@@ -24,7 +24,7 @@
         <li role="presentation"><a href="/mirror/{{ .FullName }}">Mirrored copy</a></li>
         <li role="presentation"><a href="{{ .HTMLURL }}">View on GitHub</a></li>
         {{ end }}
-        <li role="presentation"><a href="/">Back to GitHub repositories list</a></li>
+        <li role="presentation"><a href="/src/">GitHub repositories list</a></li>
       </ul>
     </div>
   </div>

--- a/templates/repo/show.html.template
+++ b/templates/repo/show.html.template
@@ -17,11 +17,11 @@
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
       <ul class="nav nav-pills">
         {{ if .Mirrored }}
-        <li role="presentation"><a href="/{{ .FullName }}">Source repository</a></li>
-        <li role="presentation" class="active"><a href="/mirror/{{ .FullName }}">Mirrored copy</a></li>
+        <li role="presentation" class="active"><a href="/{{ .FullName }}">Mirrored copy</a></li>
+        <li role="presentation"><a href="/src/{{ .FullName }}">Source repository</a></li>
         {{ else }}
-        <li role="presentation" class="active"><a href="/{{ .FullName }}">Source repository</a></li>
-        <li role="presentation"><a href="/mirror/{{ .FullName }}">Mirrored copy</a></li>
+        <li role="presentation"><a href="/{{ .FullName }}">Mirrored copy</a></li>
+        <li role="presentation" class="active"><a href="/src/{{ .FullName }}">Source repository</a></li>
         <li role="presentation"><a href="{{ .HTMLURL }}">View on GitHub</a></li>
         {{ end }}
         <li role="presentation"><a href="/src/">GitHub repositories list</a></li>

--- a/templates/repos/index.html.template
+++ b/templates/repos/index.html.template
@@ -23,16 +23,27 @@
   
   <div class="row">
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
+      {{ if .Repositories }}
       <div id="repositories-list" class="list-group">
         {{ range .Repositories }}
-          <a href="/{{ .FullName }}" class="list-group-item">
+        <a href="/{{ .FullName }}" class="list-group-item">
           <h4>{{ .FullName }}</h4>
-            {{ if .Description }}<p class="list-group-item-text">{{ .Description }}</p>{{ end }}
-          </a>
-        {{ else }}
-          <div class="well">No repositories found.</div>
+          {{ if .Description }}<p class="list-group-item-text">{{ .Description }}</p>{{ end }}
+        </a>
         {{ end }}
-      </dl>
+      </div>
+      {{ else }}
+      <div class="jumbotron">
+        <h3>No repositories found</h3>
+        <p>
+          {{ if .Mirrors }}
+          To establish a mirror go to your <a href="/src/">GitHub repositories list</a> and pick one.
+          {{ else }}
+          Check your GitHub token permissions. Consult <a href="https://github.com/andrewslotin/doppelganger/blob/master/README.md">Doppelganger README</a> for more detailed information.
+          {{ end }}
+        </p>
+      </div>
+      {{ end }}
     </div>
   </div>
 {{ end }}

--- a/templates/repos/index.html.template
+++ b/templates/repos/index.html.template
@@ -11,9 +11,9 @@
       <div id="repositories-list" class="list-group">
         {{ range . }}
           {{ if .Mirrored }}
-            <a href="/mirror/{{ .FullName }}" class="list-group-item">
-          {{ else }}
             <a href="/{{ .FullName }}" class="list-group-item">
+          {{ else }}
+            <a href="/src/{{ .FullName }}" class="list-group-item">
           {{ end }}
           <h4>{{ .FullName }}</h4>
             {{ if .Description }}<p class="list-group-item-text">{{ .Description }}</p>{{ end }}

--- a/templates/repos/index.html.template
+++ b/templates/repos/index.html.template
@@ -6,10 +6,25 @@
       </div>
     </div>
   </div>
+
+  <div class="row">
+    <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
+      <ul class="nav nav-pills">
+        {{ if .Mirrors }}
+        <li role="presentation" class="active"><a href="/">Mirrored repositories</a></li>
+        <li role="presentation"><a href="/src/">GitHub repositories</a></li>
+        {{ else }}
+        <li role="presentation"><a href="/">Mirrored repositories</a></li>
+        <li role="presentation" class="active"><a href="/src/">GitHub repositories</a></li>
+        {{ end }}
+      </ul>
+    </div>
+  </div>
+  
   <div class="row">
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
       <div id="repositories-list" class="list-group">
-        {{ range . }}
+        {{ range .Repositories }}
           <a href="/{{ .FullName }}" class="list-group-item">
           <h4>{{ .FullName }}</h4>
             {{ if .Description }}<p class="list-group-item-text">{{ .Description }}</p>{{ end }}

--- a/templates/repos/index.html.template
+++ b/templates/repos/index.html.template
@@ -10,11 +10,7 @@
     <div class="col-md-8 col-md-offset-2 col-sm-12 col-sm-offset-0">
       <div id="repositories-list" class="list-group">
         {{ range . }}
-          {{ if .Mirrored }}
-            <a href="/{{ .FullName }}" class="list-group-item">
-          {{ else }}
-            <a href="/src/{{ .FullName }}" class="list-group-item">
-          {{ end }}
+          <a href="/{{ .FullName }}" class="list-group-item">
           <h4>{{ .FullName }}</h4>
             {{ if .Description }}<p class="list-group-item-text">{{ .Description }}</p>{{ end }}
           </a>


### PR DESCRIPTION
Prefer mirrored repositories over their source:
- `/` displays the list of mirrors
- `/src/` show all GitHub repositories available with provided token
- To go to the repository mirror page just replace `github.com` part in its URL with your Doppelganger host
- To see the source repository in Doppelganger go to `/src/<repo>/<owner>`
- Improved navigation
