### PR TITLE
Graceful shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/andrewslotin/doppelganger/git"
+	"github.com/andrewslotin/doppelganger/server"
 	"github.com/bmizerany/pat"
 )
 
@@ -82,9 +83,11 @@ func main() {
 	// GitHub webhooks
 	mux.Post("/apihook", NewWebhookHandler(mirroredRepositoryService))
 
-	addr := fmt.Sprintf("%s:%d", args.addr, args.port)
-	log.Printf("doppelganger is listening on %s", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	srv := server.New(args.addr, args.port)
+	if err := srv.Run(mux); err != nil {
 		log.Panic(err)
 	}
+	log.Printf("doppelganger is listening on %s", srv.Addr)
+
+	select {}
 }

--- a/main.go
+++ b/main.go
@@ -18,8 +18,9 @@ import (
 )
 
 var (
-	// Version and BuildDate are used in help message and set by Makefile
-	Version   = "n/a"
+	// Version is used in help message and logs and set by Makefile
+	Version = "n/a"
+	// BuildDate is used in help message and set by Makefile
 	BuildDate = "n/a"
 
 	args struct {
@@ -89,7 +90,7 @@ func main() {
 	if err := srv.Run(mux); err != nil {
 		log.Panic(err)
 	}
-	log.Printf("doppelganger is listening on %s", srv.Addr)
+	log.Printf("doppelganger %s is listening on %s", Version, srv.Addr)
 
 	signals := make(chan os.Signal)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)

--- a/main.go
+++ b/main.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"golang.org/x/net/context"
 
@@ -89,5 +91,14 @@ func main() {
 	}
 	log.Printf("doppelganger is listening on %s", srv.Addr)
 
-	select {}
+	signals := make(chan os.Signal)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+
+	select {
+	case <-signals:
+		log.Println("shutdown signal received, terminating...")
+		if err := srv.Shutdown(); err != nil {
+			log.Fatal(err)
+		}
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+)
+
+// ErrNotRunning is an error returned by (*Server).Shutdown() if the server was not started yet.
+var ErrNotStarted = errors.New("server not running")
+
+// Server is a type representing an HTTP server.
+type Server struct {
+	Addr string
+
+	ln net.Listener
+	mu sync.Mutex
+}
+
+// New returns an unstarted *Server instance that serves connections on provided host:port.
+func New(host string, port int) *Server {
+	return &Server{Addr: fmt.Sprintf("%s:%d", host, port)}
+}
+
+// Run starts the server and spawns a goroutine that accepts incoming connections and handles them using http.Handler.
+func (srv *Server) Run(h http.Handler) error {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	ln, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %s", srv.Addr, err)
+	}
+	srv.ln = ln
+
+	go func(srv *http.Server, ln net.Listener) {
+		if err := srv.Serve(ln); err != nil {
+			log.Fatal(err)
+		}
+	}(&http.Server{Handler: h}, srv.ln)
+
+	return nil
+}
+
+// Shutdown terminates running server.
+func (srv *Server) Shutdown() error {
+	if srv.ln == nil {
+		return ErrNotStarted
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	if err := srv.ln.Close(); err != nil {
+		return err
+	}
+
+	srv.ln = nil
+
+	return nil
+}


### PR DESCRIPTION
- Shutdown server when SIGTERM and SIGINT are received. This makes Docker containers shutting down faster.
- Write Doppelganger version to log on start.
