### PR TITLE
Handle non git repos

### DIFF
--- a/git/system_git.go
+++ b/git/system_git.go
@@ -70,8 +70,9 @@ func (gitCmd systemGit) IsRepository(path string) bool {
 	}
 
 	output, err := gitCmd.Exec(path, "rev-parse", "--is-inside-git-dir")
-	if err != nil {
+	if err == errUnexpectedExit {
 		log.Printf("[WARN] git rev-parse --is-inside-git-dir returned %s for %s (%s)", err, path, string(output))
+	} else if err != nil {
 		return false
 	}
 


### PR DESCRIPTION
`git rev-parse` exits with non-zero status when invoked inside of directory that is not under source control. This error than bubbles up the call stack and gets rendered on the page. This PR addresses such cases by returning `false` from `git.systemGit.IsRepository(path string)` if `path` is not under source control.
