### PR TITLE
Test against Go 13.3 and tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-  - 1.11
-  - 1.11.1
+  - 1.13.3
   - tip
 
 install:


### PR DESCRIPTION
Drop support for Go versions prior to 1.13